### PR TITLE
feat: Add haskell based memory management

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,7 +55,28 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710278050,
+        "narHash": "sha256-Oc6BP7soXqb8itlHI8UKkdf3V9GeJpa1S39SR5+HJys=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "35791f76524086ab4b785a33e4abbedfda64bd22",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,9 @@
           ];
           buildInputs = with pkgs; [
             cabal-install
-            stylish-haskell
+            ormolu
             sentencepiece
+            haskell-language-server
           ];
           LD_LIBRARY_PATH = lib.makeLibraryPath [pkgs.sentencepiece];
           withHoogle = true;

--- a/flake.nix
+++ b/flake.nix
@@ -2,30 +2,44 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs = inputs @ {
     nixpkgs,
     flake-parts,
+    treefmt-nix,
     self,
   }:
     flake-parts.lib.mkFlake {
       inherit inputs;
     } {
+      imports = [inputs.treefmt-nix.flakeModule];
       systems = ["x86_64-linux"];
       perSystem = {
         system,
         pkgs,
+        config,
         lib,
         ...
       }: {
+        treefmt.config = {
+          projectRootFile = "flake.nix";
+          programs.ormolu.enable = true;
+          programs.alejandra.enable = true;
+          programs.cabal-fmt.enable = true;
+          programs.hlint.enable = true;
+        };
         packages.default = pkgs.haskellPackages.callCabal2nix "sentencepiece-haskell" ./. {};
         devShells.default = pkgs.haskellPackages.shellFor {
           packages = ps: [
             (ps.callCabal2nix "sentencepiece-haskell" ./. {})
           ];
+          inputsFrom = [
+            config.treefmt.build.devShell
+          ];
           buildInputs = with pkgs; [
             cabal-install
-            ormolu
             sentencepiece
             haskell-language-server
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
     } {
       imports = [inputs.treefmt-nix.flakeModule];
       systems = ["x86_64-linux"];
+      flake.overlays.default = final-haskell: prev-haskell: {
+        sentencepiece-haskell = final-haskell.callCabal2nix "sentencepiece-haskell" ./. {};
+      };
       perSystem = {
         system,
         pkgs,

--- a/sentencepiece-haskell.cabal
+++ b/sentencepiece-haskell.cabal
@@ -16,13 +16,24 @@ common warnings
 
 library
     import:           warnings
-    exposed-modules:  SentencePiece
+    exposed-modules:  SentencePiece,
+                      SentencePiece.Context,
+                      SentencePiece.Encapsulation,
+                      SentencePiece.Std.String,
+                      SentencePiece.Std.String.Context,
+                      SentencePiece.Std.String.Instances,
+                      SentencePiece.Std.Vector,
+                      SentencePiece.SentencePieceProcessor
     -- other-modules:
     -- other-extensions:
-    -- TODO: figure out how to include sentencepiece's include file here
     build-depends:    base ^>=4.17.2.0,
                       inline-c-cpp,
+                      inline-c,
                       template-haskell,
+                      containers,
+                      bytestring,
+                      vector,
+                      protolude,
                       directory
     hs-source-dirs:   src
     default-language: Haskell2010
@@ -32,6 +43,13 @@ library
     -- 'optcxx':      pass options to c++ compiler
     ghc-options:      -optcxx-Werror
                       -optcxx-std=c++2a
+                      -Werror=incomplete-patterns -Werror=missing-fields
+                      -Wall
+                      -fwarn-tabs
+                      -fwarn-unused-imports
+                      -fwarn-missing-signatures
+                      -fwarn-name-shadowing
+                      -fwarn-incomplete-patterns
 
     cxx-options:      -std=c++2a -Werror
 

--- a/sentencepiece-haskell.cabal
+++ b/sentencepiece-haskell.cabal
@@ -1,67 +1,75 @@
-cabal-version:      3.0
-name:               sentencepiece-haskell
-version:            0.1.0.0
+cabal-version:   3.0
+name:            sentencepiece-haskell
+version:         0.1.0.0
+
 -- synopsis:
 -- description:
-license:            NONE
-author:             Collin Arnett
-maintainer:         collin@arnett.it
+license:
+author:          Collin Arnett
+maintainer:      collin@arnett.it
+
 -- copyright:
-build-type:         Simple
-extra-doc-files:    CHANGELOG.md
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
 -- extra-source-files:
 
 common warnings
-    ghc-options: -Wall
+  ghc-options: -Wall
 
 library
-    import:           warnings
-    exposed-modules:  SentencePiece,
-                      SentencePiece.Context,
-                      SentencePiece.Encapsulation,
-                      SentencePiece.Std.String,
-                      SentencePiece.Std.String.Context,
-                      SentencePiece.Std.String.Instances,
-                      SentencePiece.Std.Vector,
-                      SentencePiece.SentencePieceProcessor
-    -- other-modules:
-    -- other-extensions:
-    build-depends:    base ^>=4.17.2.0,
-                      inline-c-cpp,
-                      inline-c,
-                      template-haskell,
-                      containers,
-                      bytestring,
-                      vector,
-                      protolude,
-                      directory
-    hs-source-dirs:   src
-    default-language: Haskell2010
-    extra-libraries:  sentencepiece,
-                      stdc++
-    extra-ghci-libraries: stdc++
-    -- 'optcxx':      pass options to c++ compiler
-    ghc-options:      -optcxx-Werror
-                      -optcxx-std=c++2a
-                      -Werror=incomplete-patterns -Werror=missing-fields
-                      -Wall
-                      -fwarn-tabs
-                      -fwarn-unused-imports
-                      -fwarn-missing-signatures
-                      -fwarn-name-shadowing
-                      -fwarn-incomplete-patterns
+  import:               warnings
+  exposed-modules:
+    SentencePiece
+    SentencePiece.Context
+    SentencePiece.Encapsulation
+    SentencePiece.SentencePieceProcessor
+    SentencePiece.Std.String
+    SentencePiece.Std.String.Context
+    SentencePiece.Std.String.Instances
+    SentencePiece.Std.Vector
 
-    cxx-options:      -std=c++2a -Werror
+  -- other-modules:
+  -- other-extensions:
+  build-depends:
+    , base              ^>=4.17.2.0
+    , bytestring
+    , containers
+    , directory
+    , inline-c
+    , inline-c-cpp
+    , protolude
+    , template-haskell
+    , vector
+
+  hs-source-dirs:       src
+  default-language:     Haskell2010
+  extra-libraries:
+    sentencepiece
+    stdc++
+
+  extra-ghci-libraries: stdc++
+
+  -- 'optcxx':      pass options to c++ compiler
+  ghc-options:
+    -optcxx-Werror -optcxx-std=c++2a -Werror=incomplete-patterns
+    -Werror=missing-fields -Wall -fwarn-tabs -fwarn-unused-imports
+    -fwarn-missing-signatures -fwarn-name-shadowing
+    -fwarn-incomplete-patterns
+
+  cxx-options:          -std=c++2a -Werror
 
 test-suite sentencepiece-haskell-test
-    import:           warnings
-    default-language: Haskell2010
-    -- other-modules:
-    -- other-extensions:
-    type:             exitcode-stdio-1.0
-    hs-source-dirs:   test
-    main-is:          Main.hs
-    build-depends:
-        base ^>=4.17.2.0,
-        sentencepiece-haskell,
-        hspec 
+  import:           warnings
+  default-language: Haskell2010
+
+  -- other-modules:
+  -- other-extensions:
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:
+    , base                   ^>=4.17.2.0
+    , hspec
+    , protolude
+    , sentencepiece-haskell

--- a/sentencepiece-haskell.cabal
+++ b/sentencepiece-haskell.cabal
@@ -32,7 +32,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-    , base              ^>=4.17.2.0
+    , base              ^>=4.16.0.0
     , bytestring
     , containers
     , directory
@@ -69,7 +69,7 @@ test-suite sentencepiece-haskell-test
   hs-source-dirs:   test
   main-is:          Main.hs
   build-depends:
-    , base                   ^>=4.17.2.0
+    , base                   ^>=4.16.0.0
     , hspec
     , protolude
     , sentencepiece-haskell

--- a/src/SentencePiece.hs
+++ b/src/SentencePiece.hs
@@ -1,53 +1,77 @@
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
 
-module SentencePiece where
-import System.Directory (makeAbsolute) 
-import           Foreign.C.String             
-import           Foreign.Ptr                  (Ptr)
-import qualified Language.C.Inline.Cpp        as C
-import qualified Language.C.Inline.Cpp.Unsafe as C
+module SentencePiece(
+  module SentencePiece,
+) where
+import           Data.ByteString                      hiding (map)
+import           Foreign.C.String
+import           Foreign.ForeignPtr
+import           Foreign.Ptr
+import qualified Language.C.Inline.Context            as C
+import qualified Language.C.Inline.Cpp                as C
+import qualified Language.C.Inline.Cpp.Unsafe         as C
+import           Protolude
+import           SentencePiece.Context
+import           SentencePiece.Encapsulation          (moveToForeignPtrWrapper)
+import           SentencePiece.SentencePieceProcessor
+import qualified SentencePiece.Std.String             as Std.String
+import           SentencePiece.Std.String             (stdStringCtx)
+import           SentencePiece.Std.String.Instances   ()
+import qualified SentencePiece.Std.Vector             as Std.Vector
+import           SentencePiece.Std.Vector             (stdVectorCtx)
+import           System.Directory                     (makeAbsolute)
 
-data SentencePieceProcessor
-data StdString
-data StdVector a
+C.context (context <> stdVectorCtx <> stdStringCtx <> C.fptrCtx)
 
-C.context $ C.cppCtx <> C.cppTypePairs [
-  ("sentencepiece::SentencePieceProcessor", [t|SentencePieceProcessor|]),
-  ("std::string", [t|StdString|]),
-  ("std::vector", [t|StdVector|])]
 
-C.include "vector"
-C.include "string"
+C.include "<cstring>"
+C.include "<string>"
+C.include "<vector>"
 C.include "sentencepiece_processor.h"
 
-string_c_str
-  :: Ptr StdString
-  -> IO String
-string_c_str str = [C.throwBlock| const char* { return (*$(std::string* str)).c_str();}|] >>= peekCString
 
-load :: FilePath -> IO (Ptr SentencePieceProcessor)
-load model = do
-  fp <- makeAbsolute model
-  withCString fp $ \cmodel -> [C.throwBlock|sentencepiece::SentencePieceProcessor* {
-    auto processor = new sentencepiece::SentencePieceProcessor();
-    processor->LoadOrDie($(char* cmodel));
-    return processor;
-}|]
+byteStringList :: IO (Ptr (Std.Vector.CStdVector Std.String.CStdString)) -> IO [ByteString]
+byteStringList x =
+  x
+    >>= moveToForeignPtrWrapper
+    >>= Std.Vector.toListFP
+    >>= traverse Std.String.copyToByteString
 
-tokenize :: Ptr SentencePieceProcessor -> String -> IO (Ptr (StdVector StdString))
-tokenize processor text = withCString text $ \ctext -> [C.throwBlock|std::vector<std::string>* {
-    std::vector<std::string>* pieces = new std::vector<std::string>();
-    $(sentencepiece::SentencePieceProcessor* processor)->Encode($(char *ctext), pieces);
-    return pieces;
-}|]
+load :: FilePath -> IO (SentencePieceProcessor)
+load fp = do
+  model <- makeAbsolute fp
+  processor <-  newSentencePieceProcessor >>= newForeignPtr deleteSentencePieceProcessor
+  withForeignPtr processor $
+      \cprocessor -> withCString model $
+        \cmodel -> [C.throwBlock|void {
+    $(sentencepiece::SentencePieceProcessor* cprocessor)->LoadOrDie($(char* cmodel));
+  }|]
+  return $ SentencePieceProcessor processor
 
-detokenize :: Ptr SentencePieceProcessor -> Ptr (StdVector StdString) -> IO String
-detokenize processor pieces = do
-  result <- [C.throwBlock|std::string* {
-   std::string* text = new std::string();
-   $(sentencepiece::SentencePieceProcessor* processor)->Decode(*$(std::vector<std::string>* pieces), text);
-   return text;
-}|]
-  string_c_str result
+encodeStr :: SentencePieceProcessor -> ByteString -> IO [ByteString]
+encodeStr (SentencePieceProcessor processor) text = byteStringList $
+  Std.String.withString text $ \cstring ->
+  withForeignPtr processor $ \cprocessor ->
+    [C.throwBlock|std::vector<std::string>* {
+      auto pieces = new std::vector<std::string>();
+      $(sentencepiece::SentencePieceProcessor* cprocessor)->Encode(*$(std::string *cstring), pieces);
+      return pieces;
+    }|]
+
+
+decodeStr :: SentencePieceProcessor -> [ByteString] -> IO ByteString
+decodeStr (SentencePieceProcessor processor) pieces = do
+  vec <- Std.Vector.new
+  for_ pieces (\p -> Std.String.withString p (Std.Vector.pushBackP vec))
+  result <- withForeignPtr processor $ \cprocessor ->
+      [C.throwBlock| std::string* {
+            auto text = new std::string();
+            $(sentencepiece::SentencePieceProcessor* cprocessor)->Decode(*$fptr-ptr:(std::vector<std::string>* vec), text);
+            return text;
+        }|]
+  Std.String.moveToByteString result

--- a/src/SentencePiece.hs
+++ b/src/SentencePiece.hs
@@ -1,39 +1,39 @@
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
-module SentencePiece(
-  module SentencePiece,
-) where
-import           Data.ByteString                      hiding (map)
-import           Foreign.C.String
-import           Foreign.ForeignPtr
-import           Foreign.Ptr
-import qualified Language.C.Inline.Context            as C
-import qualified Language.C.Inline.Cpp                as C
-import qualified Language.C.Inline.Cpp.Unsafe         as C
-import           Protolude
-import           SentencePiece.Context
-import           SentencePiece.Encapsulation          (moveToForeignPtrWrapper)
-import           SentencePiece.SentencePieceProcessor
-import qualified SentencePiece.Std.String             as Std.String
-import           SentencePiece.Std.String             (stdStringCtx)
-import           SentencePiece.Std.String.Instances   ()
-import qualified SentencePiece.Std.Vector             as Std.Vector
-import           SentencePiece.Std.Vector             (stdVectorCtx)
-import           System.Directory                     (makeAbsolute)
+module SentencePiece
+  ( module SentencePiece,
+  )
+where
+
+import Data.ByteString hiding (map)
+import Foreign.C.String
+import Foreign.ForeignPtr
+import Foreign.Ptr
+import qualified Language.C.Inline.Context as C
+import qualified Language.C.Inline.Cpp as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
+import Protolude
+import SentencePiece.Context
+import SentencePiece.Encapsulation (moveToForeignPtrWrapper)
+import SentencePiece.SentencePieceProcessor
+import SentencePiece.Std.String (stdStringCtx)
+import qualified SentencePiece.Std.String as Std.String
+import SentencePiece.Std.String.Instances ()
+import SentencePiece.Std.Vector (stdVectorCtx)
+import qualified SentencePiece.Std.Vector as Std.Vector
+import System.Directory (makeAbsolute)
 
 C.context (context <> stdVectorCtx <> stdStringCtx <> C.fptrCtx)
-
 
 C.include "<cstring>"
 C.include "<string>"
 C.include "<vector>"
 C.include "sentencepiece_processor.h"
-
 
 byteStringList :: IO (Ptr (Std.Vector.CStdVector Std.String.CStdString)) -> IO [ByteString]
 byteStringList x =
@@ -42,13 +42,14 @@ byteStringList x =
     >>= Std.Vector.toListFP
     >>= traverse Std.String.copyToByteString
 
-load :: FilePath -> IO (SentencePieceProcessor)
+load :: FilePath -> IO SentencePieceProcessor
 load fp = do
   model <- makeAbsolute fp
-  processor <-  newSentencePieceProcessor >>= newForeignPtr deleteSentencePieceProcessor
+  processor <- newSentencePieceProcessor >>= newForeignPtr deleteSentencePieceProcessor
   withForeignPtr processor $
-      \cprocessor -> withCString model $
-        \cmodel -> [C.throwBlock|void {
+    \cprocessor -> withCString model $
+      \cmodel ->
+        [C.throwBlock|void {
     $(sentencepiece::SentencePieceProcessor* cprocessor)->LoadOrDie($(char* cmodel));
   }|]
   return $ SentencePieceProcessor processor
@@ -56,20 +57,19 @@ load fp = do
 encodeStr :: SentencePieceProcessor -> ByteString -> IO [ByteString]
 encodeStr (SentencePieceProcessor processor) text = byteStringList $
   Std.String.withString text $ \cstring ->
-  withForeignPtr processor $ \cprocessor ->
-    [C.throwBlock|std::vector<std::string>* {
+    withForeignPtr processor $ \cprocessor ->
+      [C.throwBlock|std::vector<std::string>* {
       auto pieces = new std::vector<std::string>();
       $(sentencepiece::SentencePieceProcessor* cprocessor)->Encode(*$(std::string *cstring), pieces);
       return pieces;
     }|]
-
 
 decodeStr :: SentencePieceProcessor -> [ByteString] -> IO ByteString
 decodeStr (SentencePieceProcessor processor) pieces = do
   vec <- Std.Vector.new
   for_ pieces (\p -> Std.String.withString p (Std.Vector.pushBackP vec))
   result <- withForeignPtr processor $ \cprocessor ->
-      [C.throwBlock| std::string* {
+    [C.throwBlock| std::string* {
             auto text = new std::string();
             $(sentencepiece::SentencePieceProcessor* cprocessor)->Decode(*$fptr-ptr:(std::vector<std::string>* vec), text);
             return text;

--- a/src/SentencePiece.hs
+++ b/src/SentencePiece.hs
@@ -6,7 +6,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module SentencePiece
-  ( module SentencePiece,
+  ( encodeStr,
+    load,
+    decodeStr,
   )
 where
 

--- a/src/SentencePiece/Context.hs
+++ b/src/SentencePiece/Context.hs
@@ -1,22 +1,21 @@
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PolyKinds         #-}
-{-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module SentencePiece.Context where
 
-
-import qualified Data.Map                  as M
-import qualified Language.C.Inline         as C
+import qualified Data.Map as M
+import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Context as C
-import qualified Language.C.Inline.Cpp     as C
-import qualified Language.C.Types          as C
-import           Prelude
+import qualified Language.C.Inline.Cpp as C
+import qualified Language.C.Types as C
+import Prelude
 
 data CSentencePieceProcessor
 
-context:: C.Context
+context :: C.Context
 context =
   C.cppCtx
     <> mempty

--- a/src/SentencePiece/Context.hs
+++ b/src/SentencePiece/Context.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 
 module SentencePiece.Context where
 

--- a/src/SentencePiece/Context.hs
+++ b/src/SentencePiece/Context.hs
@@ -4,6 +4,11 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
+-- |
+--  This software includes modifications based on code from the "Hercules CI Agent" project
+--  (https://github.com/hercules-ci/hercules-ci-agent), licensed under the Apache License 2.0.
+--  Original Apache License 2.0 applies to these modifications.
+--  For the original license, see http://www.apache.org/licenses/LICENSE-2.0.
 module SentencePiece.Context where
 
 import qualified Data.Map as M

--- a/src/SentencePiece/Context.hs
+++ b/src/SentencePiece/Context.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds         #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module SentencePiece.Context where
+
+
+import qualified Data.Map                  as M
+import qualified Language.C.Inline         as C
+import qualified Language.C.Inline.Context as C
+import qualified Language.C.Inline.Cpp     as C
+import qualified Language.C.Types          as C
+import           Prelude
+
+data CSentencePieceProcessor
+
+context:: C.Context
+context =
+  C.cppCtx
+    <> mempty
+      { C.ctxTypesTable =
+          M.singleton (C.TypeName "sentencepiece::SentencePieceProcessor") [t|CSentencePieceProcessor|]
+      }

--- a/src/SentencePiece/Context.hs
+++ b/src/SentencePiece/Context.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module SentencePiece.Context where
 

--- a/src/SentencePiece/Encapsulation.hs
+++ b/src/SentencePiece/Encapsulation.hs
@@ -6,8 +6,8 @@ module SentencePiece.Encapsulation
   )
 where
 
-import           Foreign (Ptr, nullPtr)
-import           Prelude
+import Foreign (Ptr, nullPtr)
+import Prelude
 
 class HasEncapsulation a b | b -> a where
   -- | Takes ownership of the pointer, freeing/finalizing the pointer when

--- a/src/SentencePiece/Encapsulation.hs
+++ b/src/SentencePiece/Encapsulation.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE FunctionalDependencies #-}
 
+-- |
+--  This software includes modifications based on code from the "Hercules CI Agent" project
+--  (https://github.com/hercules-ci/hercules-ci-agent), licensed under the Apache License 2.0.
+--  Original Apache License 2.0 applies to these modifications.
+--  For the original license, see http://www.apache.org/licenses/LICENSE-2.0.
 module SentencePiece.Encapsulation
   ( HasEncapsulation (..),
     nullableMoveToForeignPtrWrapper,

--- a/src/SentencePiece/Encapsulation.hs
+++ b/src/SentencePiece/Encapsulation.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE FunctionalDependencies #-}
+
+module SentencePiece.Encapsulation
+  ( HasEncapsulation (..),
+    nullableMoveToForeignPtrWrapper,
+  )
+where
+
+import           Foreign (Ptr, nullPtr)
+import           Prelude
+
+class HasEncapsulation a b | b -> a where
+  -- | Takes ownership of the pointer, freeing/finalizing the pointer when
+  -- collectable.
+  moveToForeignPtrWrapper :: Ptr a -> IO b
+
+nullableMoveToForeignPtrWrapper :: (HasEncapsulation a b) => Ptr a -> IO (Maybe b)
+nullableMoveToForeignPtrWrapper rawPtr | rawPtr == nullPtr = pure Nothing
+nullableMoveToForeignPtrWrapper rawPtr = Just <$> moveToForeignPtrWrapper rawPtr

--- a/src/SentencePiece/SentencePieceProcessor.hs
+++ b/src/SentencePiece/SentencePieceProcessor.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TemplateHaskell       #-}
+
+module SentencePiece.SentencePieceProcessor where
+
+import           Foreign
+import qualified Language.C.Inline               as C
+import qualified Language.C.Inline.Cpp.Exception as C
+import           SentencePiece.Context
+import           SentencePiece.Encapsulation
+
+
+C.context (context)
+
+C.include "sentencepiece_processor.h"
+
+newtype SentencePieceProcessor = SentencePieceProcessor (ForeignPtr CSentencePieceProcessor)
+
+
+instance HasEncapsulation CSentencePieceProcessor  SentencePieceProcessor where
+  moveToForeignPtrWrapper x = SentencePieceProcessor <$> newForeignPtr deleteSentencePieceProcessor x
+
+newSentencePieceProcessor :: IO (Ptr CSentencePieceProcessor)
+newSentencePieceProcessor = [C.throwBlock|sentencepiece::SentencePieceProcessor* {
+  auto processor = new sentencepiece::SentencePieceProcessor();
+  return processor;
+}|]
+
+deleteSentencePieceProcessor :: FunPtr ((Ptr CSentencePieceProcessor) -> IO())
+deleteSentencePieceProcessor = [C.funPtr|
+  void delete_sentencepiece_processor(sentencepiece::SentencePieceProcessor* processor) { delete processor; }
+|]
+
+

--- a/src/SentencePiece/SentencePieceProcessor.hs
+++ b/src/SentencePiece/SentencePieceProcessor.hs
@@ -12,7 +12,7 @@ import qualified Language.C.Inline.Cpp.Exception as C
 import SentencePiece.Context
 import SentencePiece.Encapsulation
 
-C.context (context)
+C.context context
 
 C.include "sentencepiece_processor.h"
 
@@ -28,7 +28,7 @@ newSentencePieceProcessor =
   return processor;
 }|]
 
-deleteSentencePieceProcessor :: FunPtr ((Ptr CSentencePieceProcessor) -> IO ())
+deleteSentencePieceProcessor :: FunPtr (Ptr CSentencePieceProcessor -> IO ())
 deleteSentencePieceProcessor =
   [C.funPtr|
   void delete_sentencepiece_processor(sentencepiece::SentencePieceProcessor* processor) { delete processor; }

--- a/src/SentencePiece/SentencePieceProcessor.hs
+++ b/src/SentencePiece/SentencePieceProcessor.hs
@@ -1,17 +1,16 @@
-{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE QuasiQuotes           #-}
-{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module SentencePiece.SentencePieceProcessor where
 
-import           Foreign
-import qualified Language.C.Inline               as C
+import Foreign
+import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Cpp.Exception as C
-import           SentencePiece.Context
-import           SentencePiece.Encapsulation
-
+import SentencePiece.Context
+import SentencePiece.Encapsulation
 
 C.context (context)
 
@@ -19,19 +18,18 @@ C.include "sentencepiece_processor.h"
 
 newtype SentencePieceProcessor = SentencePieceProcessor (ForeignPtr CSentencePieceProcessor)
 
-
-instance HasEncapsulation CSentencePieceProcessor  SentencePieceProcessor where
+instance HasEncapsulation CSentencePieceProcessor SentencePieceProcessor where
   moveToForeignPtrWrapper x = SentencePieceProcessor <$> newForeignPtr deleteSentencePieceProcessor x
 
 newSentencePieceProcessor :: IO (Ptr CSentencePieceProcessor)
-newSentencePieceProcessor = [C.throwBlock|sentencepiece::SentencePieceProcessor* {
+newSentencePieceProcessor =
+  [C.throwBlock|sentencepiece::SentencePieceProcessor* {
   auto processor = new sentencepiece::SentencePieceProcessor();
   return processor;
 }|]
 
-deleteSentencePieceProcessor :: FunPtr ((Ptr CSentencePieceProcessor) -> IO())
-deleteSentencePieceProcessor = [C.funPtr|
+deleteSentencePieceProcessor :: FunPtr ((Ptr CSentencePieceProcessor) -> IO ())
+deleteSentencePieceProcessor =
+  [C.funPtr|
   void delete_sentencepiece_processor(sentencepiece::SentencePieceProcessor* processor) { delete processor; }
 |]
-
-

--- a/src/SentencePiece/Std/String.hs
+++ b/src/SentencePiece/Std/String.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE BlockArguments        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
+
+module SentencePiece.Std.String (
+  CStdString,
+  stdStringCtx,
+
+  moveToByteString,
+  withString,
+
+  new,
+  delete,
+
+  copyToByteString
+                                ) where
+
+import           Control.Exception                  (bracket, mask_)
+import           Data.ByteString                    (ByteString)
+import           Data.ByteString.Unsafe             (unsafePackMallocCStringLen)
+import           Foreign                            hiding (new)
+import qualified Language.C.Inline                  as C
+import           Prelude
+import           SentencePiece.Encapsulation
+import           SentencePiece.Std.String.Context
+import           SentencePiece.Std.String.Instances ()
+import           System.IO.Unsafe                   (unsafePerformIO)
+
+C.context (stdStringCtx <> C.bsCtx <> C.fptrCtx)
+
+C.include "<string>"
+C.include "<cstring>"
+
+moveToByteString :: Ptr CStdString -> IO ByteString
+moveToByteString s = mask_ $ alloca \ptr -> alloca \sz -> do
+  [C.block| void {
+    const std::string &s = *$(std::string *s);
+    size_t sz = *$(size_t *sz) = s.size();
+    char *ptr = *$(char **ptr) = (char*)malloc(sz);
+    std::memcpy((void *)ptr, s.c_str(), sz);
+  }|]
+  sz' <- peek sz
+  ptr' <- peek ptr
+  unsafePackMallocCStringLen (ptr', fromIntegral sz')
+
+new :: ByteString -> IO (Ptr CStdString)
+new bs =
+  [C.block|std::string* {
+    return new std::string($bs-ptr:bs, $bs-len:bs);
+  }|]
+
+delete :: Ptr CStdString -> IO ()
+delete bs = [C.block| void { delete $(std::string *bs); }|]
+
+withString :: ByteString -> (Ptr CStdString -> IO a) -> IO a
+withString bs = bracket (new bs) delete
+
+finalize :: FinalizerPtr CStdString
+{-# NOINLINE finalize #-}
+finalize =
+  unsafePerformIO
+    [C.exp|
+      void (*)(std::string *) {
+        [](std::string *v) {
+          delete v;
+        }
+      }
+    |]
+
+newtype StdString = StdString (ForeignPtr CStdString)
+
+instance HasEncapsulation CStdString StdString where
+  moveToForeignPtrWrapper x = StdString <$> newForeignPtr finalize x
+
+copyToByteString :: StdString -> IO ByteString
+copyToByteString (StdString s) = mask_ $ alloca \ptr -> alloca \sz -> do
+  [C.block| void {
+    const std::string &s = *$fptr-ptr:(std::string *s);
+    size_t sz = *$(size_t *sz) = s.size();
+    char *ptr = *$(char **ptr) = (char*)malloc(sz);
+    std::memcpy((void *)ptr, s.c_str(), sz);
+  }|]
+  sz' <- peek sz
+  ptr' <- peek ptr
+  unsafePackMallocCStringLen (ptr', fromIntegral sz')

--- a/src/SentencePiece/Std/String.hs
+++ b/src/SentencePiece/Std/String.hs
@@ -6,6 +6,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
+-- |
+--  This software includes modifications based on code from the "Hercules CI Agent" project
+--  (https://github.com/hercules-ci/hercules-ci-agent), licensed under the Apache License 2.0.
+--  Original Apache License 2.0 applies to these modifications.
+--  For the original license, see http://www.apache.org/licenses/LICENSE-2.0.
+--  We thank Hercules CI for their contributions to the open source community.
 module SentencePiece.Std.String
   ( CStdString,
     stdStringCtx,

--- a/src/SentencePiece/Std/String.hs
+++ b/src/SentencePiece/Std/String.hs
@@ -1,34 +1,32 @@
-{-# LANGUAGE BlockArguments        #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE QuasiQuotes           #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
-module SentencePiece.Std.String (
-  CStdString,
-  stdStringCtx,
+module SentencePiece.Std.String
+  ( CStdString,
+    stdStringCtx,
+    moveToByteString,
+    withString,
+    new,
+    delete,
+    copyToByteString,
+  )
+where
 
-  moveToByteString,
-  withString,
-
-  new,
-  delete,
-
-  copyToByteString
-                                ) where
-
-import           Control.Exception                  (bracket, mask_)
-import           Data.ByteString                    (ByteString)
-import           Data.ByteString.Unsafe             (unsafePackMallocCStringLen)
-import           Foreign                            hiding (new)
-import qualified Language.C.Inline                  as C
-import           Prelude
-import           SentencePiece.Encapsulation
-import           SentencePiece.Std.String.Context
-import           SentencePiece.Std.String.Instances ()
-import           System.IO.Unsafe                   (unsafePerformIO)
+import Control.Exception (bracket, mask_)
+import Data.ByteString (ByteString)
+import Data.ByteString.Unsafe (unsafePackMallocCStringLen)
+import Foreign hiding (new)
+import qualified Language.C.Inline as C
+import SentencePiece.Encapsulation
+import SentencePiece.Std.String.Context
+import SentencePiece.Std.String.Instances ()
+import System.IO.Unsafe (unsafePerformIO)
+import Prelude
 
 C.context (stdStringCtx <> C.bsCtx <> C.fptrCtx)
 

--- a/src/SentencePiece/Std/String/Context.hs
+++ b/src/SentencePiece/Std/String/Context.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 module SentencePiece.Std.String.Context
@@ -8,12 +8,12 @@ module SentencePiece.Std.String.Context
   )
 where
 
-import qualified Data.Map                  as M
-import qualified Language.C.Inline         as C
+import qualified Data.Map as M
+import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Context as C
-import qualified Language.C.Inline.Cpp     as C
-import qualified Language.C.Types          as C
-import           Prelude
+import qualified Language.C.Inline.Cpp as C
+import qualified Language.C.Types as C
+import Prelude
 
 data CStdString
 

--- a/src/SentencePiece/Std/String/Context.hs
+++ b/src/SentencePiece/Std/String/Context.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module SentencePiece.Std.String.Context
+  ( CStdString,
+    stdStringCtx,
+  )
+where
+
+import qualified Data.Map                  as M
+import qualified Language.C.Inline         as C
+import qualified Language.C.Inline.Context as C
+import qualified Language.C.Inline.Cpp     as C
+import qualified Language.C.Types          as C
+import           Prelude
+
+data CStdString
+
+stdStringCtx :: C.Context
+stdStringCtx =
+  C.cppCtx
+    <> mempty
+      { C.ctxTypesTable =
+          M.singleton (C.TypeName "std::string") [t|CStdString|]
+      }

--- a/src/SentencePiece/Std/String/Instances.hs
+++ b/src/SentencePiece/Std/String/Instances.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Define instances for C++ types in the Context module that can't be in that
+-- module because of TH staging restrictions.
+module SentencePiece.Std.String.Instances () where
+
+import           Data.Semigroup                   (Semigroup ((<>)))
+import qualified Language.C.Inline.Cpp            as C
+import           SentencePiece.Std.String.Context
+import           SentencePiece.Std.Vector
+
+C.context (stdVectorCtx <> stdStringCtx)
+C.include "<string>"
+
+instanceStdVector "std::string"

--- a/src/SentencePiece/Std/String/Instances.hs
+++ b/src/SentencePiece/Std/String/Instances.hs
@@ -2,11 +2,15 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
--- | Define instances for C++ types in the Context module that can't be in that
--- module because of TH staging restrictions.
+-- |
+--  This software includes modifications based on code from the "Hercules CI Agent" project
+--  (https://github.com/hercules-ci/hercules-ci-agent), licensed under the Apache License 2.0.
+--  Original Apache License 2.0 applies to these modifications.
+--  For the original license, see http://www.apache.org/licenses/LICENSE-2.0.
+--  We thank Hercules CI for their contributions to the open source community.
 module SentencePiece.Std.String.Instances () where
 
-import Data.Semigroup (Semigroup ((<>)))
+import Data.Semigroup ()
 import qualified Language.C.Inline.Cpp as C
 import SentencePiece.Std.String.Context
 import SentencePiece.Std.Vector

--- a/src/SentencePiece/Std/String/Instances.hs
+++ b/src/SentencePiece/Std/String/Instances.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Define instances for C++ types in the Context module that can't be in that
 -- module because of TH staging restrictions.
 module SentencePiece.Std.String.Instances () where
 
-import           Data.Semigroup                   (Semigroup ((<>)))
-import qualified Language.C.Inline.Cpp            as C
-import           SentencePiece.Std.String.Context
-import           SentencePiece.Std.Vector
+import Data.Semigroup (Semigroup ((<>)))
+import qualified Language.C.Inline.Cpp as C
+import SentencePiece.Std.String.Context
+import SentencePiece.Std.Vector
 
 C.context (stdVectorCtx <> stdStringCtx)
 C.include "<string>"

--- a/src/SentencePiece/Std/Vector.hs
+++ b/src/SentencePiece/Std/Vector.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE QuasiQuotes           #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 
 -- | @std::vector@
@@ -31,19 +31,19 @@ module SentencePiece.Std.Vector
   )
 where
 
-import           Control.Exception            (mask_)
-import           Data.Coerce                  (Coercible, coerce)
-import           Data.Foldable
-import qualified Data.Vector.Storable         as VS
+import Control.Exception (mask_)
+import Data.Coerce (Coercible, coerce)
+import Data.Foldable
+import qualified Data.Vector.Storable as VS
 import qualified Data.Vector.Storable.Mutable as VSM
-import           Foreign
-import           Foreign.C
-import qualified Language.C.Inline            as C
-import qualified Language.C.Inline.Cpp        as C
-import qualified Language.C.Inline.Unsafe     as CU
-import           Language.Haskell.TH
-import           Prelude
-import           SentencePiece.Encapsulation
+import Foreign
+import Foreign.C
+import qualified Language.C.Inline as C
+import qualified Language.C.Inline.Cpp as C
+import qualified Language.C.Inline.Unsafe as CU
+import Language.Haskell.TH
+import SentencePiece.Encapsulation
+import Prelude
 
 data CStdVector a
 

--- a/src/SentencePiece/Std/Vector.hs
+++ b/src/SentencePiece/Std/Vector.hs
@@ -7,9 +7,16 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 
--- | @std::vector@
+-- \| @std::vector@
 --
 -- Original author @chpatrick https://github.com/fpco/inline-c/blob/1ba35141e330981fef0457a1619701b8acc32f0b/inline-c-cpp/test/StdVector.hs
+
+-- |
+--  This software includes modifications based on code from the "Hercules CI Agent" project
+--  (https://github.com/hercules-ci/hercules-ci-agent), licensed under the Apache License 2.0.
+--  Original Apache License 2.0 applies to these modifications.
+--  For the original license, see http://www.apache.org/licenses/LICENSE-2.0.
+--  We thank Hercules CI for their contributions to the open source community.
 module SentencePiece.Std.Vector
   ( stdVectorCtx,
     instanceStdVector,

--- a/src/SentencePiece/Std/Vector.hs
+++ b/src/SentencePiece/Std/Vector.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+
+-- | @std::vector@
+--
+-- Original author @chpatrick https://github.com/fpco/inline-c/blob/1ba35141e330981fef0457a1619701b8acc32f0b/inline-c-cpp/test/StdVector.hs
+module SentencePiece.Std.Vector
+  ( stdVectorCtx,
+    instanceStdVector,
+    instanceStdVectorCopyable,
+    CStdVector,
+    StdVector (StdVector),
+    SentencePiece.Std.Vector.new,
+    size,
+    toVector,
+    toVectorP,
+    toListP,
+    toListFP,
+    SentencePiece.Std.Vector.toList,
+    SentencePiece.Std.Vector.fromList,
+    fromListFP,
+    pushBack,
+    pushBackP,
+    pushBackFP,
+  )
+where
+
+import           Control.Exception            (mask_)
+import           Data.Coerce                  (Coercible, coerce)
+import           Data.Foldable
+import qualified Data.Vector.Storable         as VS
+import qualified Data.Vector.Storable.Mutable as VSM
+import           Foreign
+import           Foreign.C
+import qualified Language.C.Inline            as C
+import qualified Language.C.Inline.Cpp        as C
+import qualified Language.C.Inline.Unsafe     as CU
+import           Language.Haskell.TH
+import           Prelude
+import           SentencePiece.Encapsulation
+
+data CStdVector a
+
+stdVectorCtx :: C.Context
+stdVectorCtx = C.cppCtx `mappend` C.cppTypePairs [("std::vector", [t|CStdVector|])]
+
+newtype StdVector a = StdVector (ForeignPtr (CStdVector a))
+
+instance (HasStdVector a) => HasEncapsulation (CStdVector a) (StdVector a) where
+  moveToForeignPtrWrapper x = StdVector <$> newForeignPtr cDelete x
+
+class HasStdVector a where
+  cNew :: IO (Ptr (CStdVector a))
+  cDelete :: FunPtr (Ptr (CStdVector a) -> IO ())
+  cSize :: Ptr (CStdVector a) -> IO CSize
+  cCopies :: Ptr (CStdVector a) -> Ptr (Ptr a) -> IO ()
+  cPushBackByPtr :: Ptr a -> Ptr (CStdVector a) -> IO ()
+
+class (HasStdVector a) => HasStdVectorCopyable a where
+  cCopyTo :: Ptr (CStdVector a) -> Ptr a -> IO ()
+  cPushBack :: a -> Ptr (CStdVector a) -> IO ()
+
+-- | Helper for defining templated instances
+roll :: String -> Q [Dec] -> Q [Dec]
+roll cType d =
+  concat
+    <$> sequence
+      [ C.include "<vector>",
+        C.include "<algorithm>",
+        C.substitute
+          [ ("T", const cType),
+            ("VEC", \var -> "$(std::vector<" ++ cType ++ ">* " ++ var ++ ")")
+          ]
+          d
+      ]
+
+instanceStdVector :: String -> DecsQ
+instanceStdVector cType =
+  roll
+    cType
+    [d|
+      instance HasStdVector $(C.getHaskellType False cType) where
+        cNew = [CU.exp| std::vector<@T()>* { new std::vector<@T()>() } |]
+        cDelete = [C.funPtr| void deleteStdVector(std::vector<@T()>* vec) { delete vec; } |]
+        cSize vec = [CU.exp| size_t { @VEC(vec)->size() } |]
+
+        cCopies vec dstPtr =
+          [CU.block| void {
+          const std::vector<@T()>& vec = *@VEC(vec);
+          @T()** aim = $(@T()** dstPtr);
+          for (auto item : vec) {
+            *aim = new @T()(item);
+            aim++;
+          }
+        }|]
+        cPushBackByPtr ptr vec = [CU.exp| void { @VEC(vec)->push_back(*$(@T() *ptr)) } |]
+      |]
+
+instanceStdVectorCopyable :: String -> DecsQ
+instanceStdVectorCopyable cType =
+  roll
+    cType
+    [d|
+      instance HasStdVectorCopyable $(C.getHaskellType False cType) where
+        cCopyTo vec dstPtr =
+          [CU.block| void {
+          const std::vector<@T()>* vec = @VEC(vec);
+          std::copy(vec->begin(), vec->end(), $(@T()* dstPtr));
+          } |]
+        cPushBack value vec = [CU.exp| void { @VEC(vec)->push_back($(@T() value)) } |]
+      |]
+
+new :: forall a. (HasStdVector a) => IO (StdVector a)
+new = mask_ $ do
+  ptr <- cNew @a
+  StdVector <$> newForeignPtr cDelete ptr
+
+size :: (HasStdVector a) => StdVector a -> IO Int
+size (StdVector fptr) = fromIntegral <$> withForeignPtr fptr cSize
+
+toVector :: (HasStdVectorCopyable a, Storable a) => StdVector a -> IO (VS.Vector a)
+toVector stdVec@(StdVector stdVecFPtr) = do
+  vecSize <- size stdVec
+  hsVec <- VSM.new vecSize
+  withForeignPtr stdVecFPtr $ \stdVecPtr ->
+    VSM.unsafeWith hsVec $ \hsVecPtr ->
+      cCopyTo stdVecPtr hsVecPtr
+  VS.unsafeFreeze hsVec
+
+toVectorP :: (HasStdVector a) => StdVector a -> IO (VS.Vector (Ptr a))
+toVectorP stdVec@(StdVector stdVecFPtr) = do
+  vecSize <- size stdVec
+  hsVec <- VSM.new vecSize
+  withForeignPtr stdVecFPtr $ \stdVecPtr ->
+    VSM.unsafeWith hsVec $ \hsVecPtr ->
+      cCopies stdVecPtr hsVecPtr
+  VS.unsafeFreeze hsVec
+
+fromList :: (HasStdVectorCopyable a) => [a] -> IO (StdVector a)
+fromList as = do
+  vec <- SentencePiece.Std.Vector.new
+  for_ as $ \a -> pushBack vec a
+  pure vec
+
+fromListFP :: (Coercible a' (ForeignPtr a), HasStdVector a) => [a'] -> IO (StdVector a)
+fromListFP as = do
+  vec <- SentencePiece.Std.Vector.new
+  for_ as $ \a -> pushBackFP vec a
+  pure vec
+
+toList :: (HasStdVectorCopyable a, Storable a) => StdVector a -> IO [a]
+toList vec = VS.toList <$> toVector vec
+
+toListP :: (HasStdVector a) => StdVector a -> IO [Ptr a]
+toListP vec = VS.toList <$> toVectorP vec
+
+toListFP :: (HasEncapsulation a b, HasStdVector a) => StdVector a -> IO [b]
+toListFP vec = traverse moveToForeignPtrWrapper =<< toListP vec
+
+pushBack :: (HasStdVectorCopyable a) => StdVector a -> a -> IO ()
+pushBack (StdVector fptr) value = withForeignPtr fptr (cPushBack value)
+
+pushBackP :: (HasStdVector a) => StdVector a -> Ptr a -> IO ()
+pushBackP (StdVector fptr) valueP = withForeignPtr fptr (cPushBackByPtr valueP)
+
+pushBackFP :: (Coercible a' (ForeignPtr a), HasStdVector a) => StdVector a -> a' -> IO ()
+pushBackFP vec vfptr = withForeignPtr (coerce vfptr) (pushBackP vec)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,10 +1,10 @@
 module Main (main) where
 
 import SentencePiece
-  
+
 main :: IO ()
-main =  do
+main = do
   processor <- load "./test/test_model.model"
   tokens <- tokenize processor "Hello World"
   str <- detokenize processor tokens
-  putStrLn str 
+  putStrLn str

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,10 +5,18 @@ module Main (main) where
 import Data.String
 import Protolude
 import SentencePiece
+import Test.Hspec
 
 main :: IO ()
-main = do
-  processor <- load "./test/test_model.model"
-  tokens <- encodeStr processor $ fromString "Hello World"
-  str <- decodeStr processor tokens
-  putStrLn str
+main = hspec $ do
+  describe "SentencePiece.encodeStr" $ do
+    it "encodes a bytestring to a list of tokens" $ do
+      processor <- load "./test/test_model.model"
+      encodeStr processor input `shouldReturn` (output :: [ByteString])
+  describe "SentencePiece.decodeStr" $ do
+    it "decodes a list of tokens to a bytestring" $ do
+      processor <- load "./test/test_model.model"
+      decodeStr processor output `shouldReturn` (input :: ByteString)
+  where
+    input = fromString "Hello World"
+    output = map fromString ["â\150\129He", "ll", "o", "â\150\129", "W", "or", "l", "d"]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Main (main) where
 
+import Data.String
+import Protolude
 import SentencePiece
 
 main :: IO ()
 main = do
   processor <- load "./test/test_model.model"
-  tokens <- tokenize processor "Hello World"
-  str <- detokenize processor tokens
+  tokens <- encodeStr processor $ fromString "Hello World"
+  str <- decodeStr processor tokens
   putStrLn str


### PR DESCRIPTION
This pull request allows haskell to manage the memory associated with foreign pointers to C++ objects. 

To complete this draft the following tasks must be accomplished:

* Add proper attributions to [hercules-ci-agent](https://github.com/hercules-ci/hercules-ci-agent/tree/9fc9b2c161b297b964701828feb4d4d7be4e48f9/hercules-ci-cnix-store/src/Hercules/CNix)
* Create a `HasEncapsulation` instance for `SentencePieceProcessor`
* Add Hspec tests
* Refactor functions to use Applicative and Comonad where appropriate.
* Remove unneeded imports
* Add CI to format with ormolu.
* Add overlay to export package via nix